### PR TITLE
fix drop folder file conflict

### DIFF
--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -213,7 +213,7 @@ OC.Upload = {
 			//avoid drop folder conflict error
 			//check relativepath before check conflict
                         var relativePath = upload.files[0].relativePath;
-                        relativePath = (relativePath == "" || relativePath == null) ? true : false;
+                        relativePath = (relativePath === "" || relativePath === null) ? true : false;
 			if (fileInfo && relativePath) {
 				conflicts.push([
 					// original

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -210,7 +210,16 @@ OC.Upload = {
 		// only keep non-conflicting uploads
 		selection.uploads = _.filter(selection.uploads, function(upload) {
 			var fileInfo = fileList.findFile(upload.files[0].name);
-			if (fileInfo) {
+			//avoid drop folder conflict error
+			//check relativepath before check conflict
+                        var relativePath = upload.files[0].relativePath;
+                        if (relativePath == "" ||  relativePath == null){
+                                relativePath = true;
+                        }
+                        else{
+                                relativePath = false;
+                        }
+			if (fileInfo && relativePath) {
 				conflicts.push([
 					// original
 					_.extend(fileInfo, {

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -213,12 +213,7 @@ OC.Upload = {
 			//avoid drop folder conflict error
 			//check relativepath before check conflict
                         var relativePath = upload.files[0].relativePath;
-                        if (relativePath == "" ||  relativePath == null){
-                                relativePath = true;
-                        }
-                        else{
-                                relativePath = false;
-                        }
+                        relativePath = (relativePath == "" || relativePath == null) ? true : false;
 			if (fileInfo && relativePath) {
 				conflicts.push([
 					// original

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -213,7 +213,7 @@ OC.Upload = {
 			//avoid drop folder conflict error
 			//check relativepath before check conflict
                         var relativePath = upload.files[0].relativePath;
-                        relativePath = (relativePath === "" || relativePath === null) ? true : false;
+                        relativePath = (relativePath === "" || relativePath === null || relativePath == undefined) ? true : false;
 			if (fileInfo && relativePath) {
 				conflicts.push([
 					// original

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -213,7 +213,7 @@ OC.Upload = {
 			//avoid drop folder conflict error
 			//check relativepath before check conflict
                         var relativePath = upload.files[0].relativePath;
-                        relativePath = (relativePath === "" || relativePath === null || relativePath == undefined) ? true : false;
+                        relativePath = (relativePath === "" || relativePath === null || relativePath === undefined) ? true : false;
 			if (fileInfo && relativePath) {
 				conflicts.push([
 					// original


### PR DESCRIPTION
In version 8.2.1, owcloud use new method to check file conflict in js
But if using drop folder to upload, new method did not check files relativepath, this will casue file conflict error.
