### PR TITLE
[feature] To ehance handle file lock when owncloud failed with our

### DIFF
--- a/db_structure.xml
+++ b/db_structure.xml
@@ -1265,5 +1265,59 @@
 
 	</table>
 
+        <table>
 
+		<!--
+		Table for storing transactional file locking on hosts
+		-->
+		<name>*dbprefix*host_locks</name>
+
+		<declaration>
+
+			<field>
+				<name>id</name>
+				<type>integer</type>
+				<default>0</default>
+				<notnull>true</notnull>
+				<unsigned>true</unsigned>
+				<length>4</length>
+				<autoincrement>1</autoincrement>
+			</field>
+
+			<field>
+				<name>hostname</name>
+				<type>text</type>
+				<notnull>true</notnull>
+				<length>512</length>
+			</field>
+
+			<field>
+				<name>key</name>
+				<type>text</type>
+				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+
+			<index>
+				<unique>true</unique>
+				<name>lock_key_index</name>
+				<field>
+					<name>key</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+			<index>
+				<primary>true</primary>
+				<unique>true</unique>
+				<name>host_lock_id_index</name>
+				<field>
+					<name>id</name>
+					<sorting>ascending</sorting>
+				</field>
+			</index>
+
+		</declaration>
+
+	</table>
 </database>

--- a/lib/private/lock/ehancedblockingprovider.php
+++ b/lib/private/lock/ehancedblockingprovider.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @author Individual IT Services <info@individual-it.net>
+ * @author Robin Appelman <icewind@owncloud.com>
+ * @author Duncan Chiang <duncan.c@inwinstack.com>
+ *
+ * @copyright Copyright (c) 2016, ownCloud, Inc.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Lock;
+
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\IDBConnection;
+use OCP\ILogger;
+use OCP\Lock\ILockingProvider;
+use OCP\Lock\LockedException;
+/**
+ * Locking provider that stores the locks in the database
+ */
+class EhanceDBLockingProvider extends DBLockingProvider {
+    public function __construct(IDBConnection $connection, ILogger $logger, ITimeFactory $timeFactory) {
+        $this->connection = $connection;
+        $this->logger = $logger;
+        $this->timeFactory = $timeFactory;
+        parent::__construct($connection, $logger, $timeFactory);
+    }
+    
+    public function acquireLock($path, $type) {
+        parent::acquireLock($path, $type);
+        $hostName = gethostname();
+        
+        $sqlCmd = "INSERT INTO `*PREFIX*host_locks` (`hostname`,`key`)
+                   SELECT ?,?
+                   FROM DUAL
+                   WHERE EXISTS (SELECT * FROM `*PREFIX*file_locks` WHERE `key` = ? LIMIT 1)
+                   AND NOT EXISTS (SELECT * FROM `*PREFIX*host_locks` WHERE `key` = ? LIMIT 1)
+                  ";
+        $result = $this->connection->executeUpdate($sqlCmd,[$hostName, $path, $path,$path]);
+    }
+    
+    public function releaseAll() {
+        parent::releaseAll();
+        $hostName = gethostname();
+        $sqlCmd = "DELETE `*PREFIX*host_locks`
+    		   FROM `*PREFIX*host_locks` INNER JOIN `*PREFIX*file_locks`
+    		   ON `*PREFIX*host_locks`.`key` = `*PREFIX*file_locks`.`key`
+    		   AND `*PREFIX*file_locks`.`lock` = 0
+    		   AND `*PREFIX*host_locks`.`hostname` = ?
+	          ";
+        $result = $this->connection->executeUpdate($sqlCmd,[$hostName]);
+    }
+}
+

--- a/lib/private/server.php
+++ b/lib/private/server.php
@@ -52,6 +52,7 @@ use OC\Files\Node\Root;
 use OC\Files\View;
 use OC\Http\Client\ClientService;
 use OC\Lock\DBLockingProvider;
+use OC\Lock\EhanceDBLockingProvider;
 use OC\Lock\MemcacheLockingProvider;
 use OC\Lock\NoopLockingProvider;
 use OC\Mail\Mailer;
@@ -463,6 +464,9 @@ class Server extends SimpleContainer implements IServerContainer {
 				$memcache = $memcacheFactory->createLocking('lock');
 				if (!($memcache instanceof \OC\Memcache\NullCache)) {
 					return new MemcacheLockingProvider($memcache);
+				}
+                                if ($c->getConfig()->getSystemValue('ehancedblock', false)){
+				    return new EhanceDBLockingProvider($c->getDatabaseConnection(), $c->getLogger(), new TimeFactory());
 				}
 				return new DBLockingProvider($c->getDatabaseConnection(), $c->getLogger(), new TimeFactory());
 			}


### PR DESCRIPTION
```
 To ehance handle file lock when owncloud failed with our
          consul service.
1. Create `*PREFIX*host_locks` table in db. Note if your owncloud
   is running, You must create the `*PREFIX*host_locks` manually.
2. Set 'ehancedblock' => true in config.php, and then you will use
   EhanceDBLockingProvider.
```
