### PR TITLE
[bugfix] the API of create user.

### DIFF
--- a/settings/controller/userscontroller.php
+++ b/settings/controller/userscontroller.php
@@ -301,10 +301,10 @@ class UsersController extends Controller {
 			}
 		}
         
-        if (preg_match("/(?=^\.|^_)|(?=\W+)(?!\.)/",$username)) {
+        if (preg_match("/(?=^\.|^_|^\@)|(?=\W+)(?!\.)(?!\@)/",$username)) {
             return new DataResponse(
                 array(
-                    'message' => (string)$this->l10n->t('Username can only use English letters(case-insensitive), Number, Baseline(_) and dot(.). But Username can\'t start with Baseline(_) or dot(.).')
+                    'message' => (string)$this->l10n->t('Username can only use English letters(case-insensitive), Number, Baseline(_) , Dot(.) and At(@). But Username can\'t start with Baseline(_) , Dot(.) or At(@).')
                 ),
                 Http::STATUS_CONFLICT
             );

--- a/settings/l10n/zh_TW.json
+++ b/settings/l10n/zh_TW.json
@@ -104,7 +104,7 @@
     "Error creating user" : "建立使用者時出現錯誤",
     "A valid password must be provided" : "一定要提供一個有效的密碼",
     "A valid email must be provided" : "必須提供一個有效的電子郵件地址",
-    "Username can only use English letters(case-insensitive), Number, Baseline(_) and dot(.). But Username can't start with Baseline(_) or dot(.)." : "用戶名僅能使用英文字母(不分大小寫),數字,底線(_)以及句號(.)。但是不能使用底線(_)或是句號(.)當開頭",
+    "Username can only use English letters(case-insensitive), Number, Baseline(_) , Dot(.) and At(@). But Username can't start with Baseline(_) , Dot(.)or At(@)." : "用戶名僅能使用英文字母(不分大小寫),數字,底線(_),句號(.)以及@。但是不能使用底線(_),句號(.)或是@當開頭",
     "Groupname can only use English letters(case-insensitive), Number, Baseline(_) and dot(.). But Groupname can't start with Baseline(_) or dot(.)." : "群組名僅能使用英文字母(不分大小寫),數字,底線(_)以及句號(.)。但是不能使用底線(_)或是句號(.)當開頭",
     "__language_name__" : "__language_name__",
     "Personal info" : "個人資訊",


### PR DESCRIPTION
In the lastest API of create user, I filter the special character.
But administrative users create the user's account, the account should
be acceptable the email format.
And I modify the translated message about create user with error special
character.
