### PR TITLE
share permission init readonly

### DIFF
--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -610,24 +610,30 @@ class Share extends Constants {
         $config = \OC::$server->getConfig();
         $reshareble = $config->getAppValue('core', 'shareapi_allow_resharing') == 'yes' ? true : false;
         $rule = \OC_Config::getValue('permissions');
+        $create = isset($rule['create']) ? $rule['create'] : true;
+        $delete = isset($rule['delete']) ? $rule['delete'] : true;
+        $update = isset($rule['update']) ? $rule['update'] : true;
+        $reshare = isset($rule['reshare']) ? $rule['reshare'] : true;
+
+
         if($shareType != self::SHARE_TYPE_LINK) {
             if($itemType == 'folder' || $shareType == self::SHARE_TYPE_REMOTE) {
-                if(!$rule['create']) {
+                if(!$create) {
                     $permissions -= \OCP\Constants::PERMISSION_CREATE;
                 }
 
-                if(!$rule['delete'] && $itemType == 'folder') {
+                if(!$delete && $itemType == 'folder') {
                     
                     $permissions -= \OCP\Constants::PERMISSION_DELETE;
                 }
             }
 
-            if(!$rule['update']) {
+            if(!$update) {
                 $permissions -= \OCP\Constants::PERMISSION_UPDATE;
 
             }
 
-            if(!$rule['reshare'] && $reshareble) {
+            if(!$reshare && $reshareble) {
                 $permissions -= \OCP\Constants::PERMISSION_SHARE;
             }
         }

--- a/lib/private/share/share.php
+++ b/lib/private/share/share.php
@@ -606,6 +606,31 @@ class Share extends Constants {
 
 		$backend = self::getBackend($itemType);
 		$l = \OC::$server->getL10N('lib');
+        
+        $config = \OC::$server->getConfig();
+        $reshareble = $config->getAppValue('core', 'shareapi_allow_resharing') == 'yes' ? true : false;
+        $rule = \OC_Config::getValue('permissions');
+        if($shareType != self::SHARE_TYPE_LINK) {
+            if($itemType == 'folder' || $shareType == self::SHARE_TYPE_REMOTE) {
+                if(!$rule['create']) {
+                    $permissions -= \OCP\Constants::PERMISSION_CREATE;
+                }
+
+                if(!$rule['delete'] && $itemType == 'folder') {
+                    
+                    $permissions -= \OCP\Constants::PERMISSION_DELETE;
+                }
+            }
+
+            if(!$rule['update']) {
+                $permissions -= \OCP\Constants::PERMISSION_UPDATE;
+
+            }
+
+            if(!$rule['reshare'] && $reshareble) {
+                $permissions -= \OCP\Constants::PERMISSION_SHARE;
+            }
+        }
 
 		if ($backend->isShareTypeAllowed($shareType) === false) {
 			$message = 'Sharing %s failed, because the backend does not allow shares from type %i';


### PR DESCRIPTION
In config.php add a permissions array.
This array can set create, update, reshare, delete permissions.
And permissions array like this

$permissions => array(
   'reshare' => false,
   'create' => false,
   'update' => false,
   'delete' => false,
)
